### PR TITLE
Add `files` field to package.json to prevent publishing extra files

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,7 @@
     "package.json",
     "index.js",
     "README.md",
-    "LICENSE",
-    ".eslintrc",
-    ".editorconfig"
+    "LICENSE"
   ],
   "scripts": {
     "lint": "eslint ."

--- a/package.json
+++ b/package.json
@@ -3,6 +3,14 @@
   "version": "2.0.0",
   "description": "Care/Of's shared ESLint Config",
   "main": "index.js",
+  "files": [
+    "package.json",
+    "index.js",
+    "README.md",
+    "LICENSE",
+    ".eslintrc",
+    ".editorconfig"
+  ],
   "scripts": {
     "lint": "eslint ."
   },


### PR DESCRIPTION
When I [published] v2.0.0, I had some extra files in the directory, and
they would have been included had I not noticed them in the list that
`npm publish` prints and removed them. Thankfully, the 2FA requirement
gave me an opportunity to do that, but this change should make it so
that it can't happen, even if the publisher isn't paying attention.

See here for documentation on how this field works:
https://docs.npmjs.com/files/package.json#files

[published]: https://careof.slack.com/archives/C0LMGB30U/p1594411360307500?thread_ts=1594396228.303800&cid=C0LMGB30U